### PR TITLE
Add support for optionnal 4th col in known_hosts

### DIFF
--- a/sshfp
+++ b/sshfp
@@ -169,7 +169,8 @@ def process_records(data, hostnames):
 		if record.startswith("#") or not record:
 			continue
 		try:
-			(host, keytype, key) = record.split(" ")
+			# Ignore optionnal 4th column "root@localhost"
+			(host, keytype, key) = record.split(" ")[:3]
 		except ValueError:
 			if not quiet:
 				print >> sys.stdout, "Print unable to read record '%s'" % record


### PR DESCRIPTION
Some known_hosts file are built from raw id_*.pub files. They do contain the friendly name like root@localhost as the fourth column.
sshfp assume there are exactly 3 columns and crashes is there's a fourth one.

This patch keep only the 3 first items of each line before processing.
