### PR TITLE
openpgpkey: hash username as SHA2-256 truncated to 28 octets

### DIFF
--- a/openpgpkey
+++ b/openpgpkey
@@ -33,7 +33,7 @@ def getOPENPGPKEY(email,insecure_ok):
 	global ctx
 
 	try:
-		username, domainname = email.split("@")
+		username, domainname = email.lower().split("@")
 	except:
 		sys.exit("Invalid email syntax")
 
@@ -215,7 +215,7 @@ if __name__ == '__main__':
 
 		# show it
 		ekey64 = "".join(gpgdisk.export_keys(pgpkey["keyid"],minimal=True, secret=False, armor=True).split("\n")[2:-3])
-		user,domain = args.email.split("@")
+		user,domain = args.email.lower().split("@")
 		euser = sha256trunc(user)
 
 		if args.output == "rfc" or args.output == "both":

--- a/openpgpkey
+++ b/openpgpkey
@@ -13,7 +13,7 @@ import sys
 import os
 import gnupg
 import unbound
-from hashlib import sha224
+import hashlib
 import tempfile
 import shutil
 
@@ -22,6 +22,10 @@ global ctx
 def asctohex(s):
     empty = '' # I use this construct because I find ''.join() too dense
     return empty.join(['%02x' % ord(c) for c in s]) # the %02 pads when needed
+
+def sha256trunc(data):
+	"""Compute SHA2-256 hash truncated to 28 octets."""
+	return hashlib.sha256(data).hexdigest()[:56]
 
 def getOPENPGPKEY(email,insecure_ok):
 	"""This function queries for an OPENPGPKEY DNS Resource Record and compares it with the local gnupg keyring"""
@@ -33,7 +37,7 @@ def getOPENPGPKEY(email,insecure_ok):
 	except:
 		sys.exit("Invalid email syntax")
 
-	keyname = "%s._openpgpkey.%s"%(sha224(username).hexdigest() ,domainname)
+	keyname = "%s._openpgpkey.%s"%(sha256trunc(username), domainname)
 
 	status, result = ctx.resolve(keyname, OPENPGPKEY)
 	if status == 0 and result.havedata:
@@ -212,7 +216,7 @@ if __name__ == '__main__':
 		# show it
 		ekey64 = "".join(gpgdisk.export_keys(pgpkey["keyid"],minimal=True, secret=False, armor=True).split("\n")[2:-3])
 		user,domain = args.email.split("@")
-		euser = sha224(user).hexdigest()
+		euser = sha256trunc(user)
 
 		if args.output == "rfc" or args.output == "both":
 			print "; keyid: %s"%(pgpkey["keyid"])


### PR DESCRIPTION
SHA2-244 is replaced by SHA2-256 truncated to 28 octets.

This reflects recent changes in draft-ietf-dane-openpgpkey. 
