### PR TITLE
add SNI to TLSA tool and don't prevent generating port 25 data for lo…

### DIFF
--- a/tlsa
+++ b/tlsa
@@ -453,7 +453,7 @@ if __name__ == '__main__':
 	if args.host[-1] != '.':
 		args.host += '.'
 
-	if args.port == "25":
+	if args.port == "25" and not args.certificate:
 		print >> sys.stdout, 'STARTTLS on port 25 is not yet supported'
 		sys.exit(1)
 
@@ -531,6 +531,12 @@ if __name__ == '__main__':
 				else:
 					sock = None
 				connection = SSL.Connection(ctx, sock=sock)
+				try:
+					connection.set_tlsext_host_name(args.host)
+				except AttributeError:
+					print 'Could not set SNI (old M2Crypto version?)'
+				except:
+					print 'Could not set SNI'
 				try:
 					connection.connect((str(address), int(args.port)))
 				except SSL.Checker.WrongHost, e:
@@ -670,6 +676,12 @@ if __name__ == '__main__':
 				else:
 					sock = None
 				connection = SSL.Connection(ctx, sock=sock)
+				try:
+					connection.set_tlsext_host_name(args.host)
+				except AttributeError:
+					print 'Could not set SNI (old M2Crypto version?)'
+				except:
+					print 'Could not set SNI'
 				try:
 					connection.connect((str(address), int(connection_port)))
 				except SSL.Checker.WrongHost:

--- a/tlsa
+++ b/tlsa
@@ -452,6 +452,7 @@ if __name__ == '__main__':
 
 	if args.host[-1] != '.':
 		args.host += '.'
+	snihost = args.host[0:-1]
 
 	if args.port == "25" and not args.certificate:
 		print >> sys.stdout, 'STARTTLS on port 25 is not yet supported'
@@ -532,7 +533,10 @@ if __name__ == '__main__':
 					sock = None
 				connection = SSL.Connection(ctx, sock=sock)
 				try:
-					connection.set_tlsext_host_name(args.host)
+					
+					connection.set_tlsext_host_name(snihost)
+					if(args.debug):
+						print 'Did set servername %s' % snihost
 				except AttributeError:
 					print 'Could not set SNI (old M2Crypto version?)'
 				except:
@@ -677,7 +681,9 @@ if __name__ == '__main__':
 					sock = None
 				connection = SSL.Connection(ctx, sock=sock)
 				try:
-					connection.set_tlsext_host_name(args.host)
+					connection.set_tlsext_host_name(snihost)
+					if(args.debug):
+						print 'Did set servername %s' % snihost
 				except AttributeError:
 					print 'Could not set SNI (old M2Crypto version?)'
 				except:


### PR DESCRIPTION
Fixes issue #2 and also allows usage of SNI which is supported by recent M2Crypto versions.
