### PR TITLE
don't print the repr of a bytes literal for TLSA mtype 0, plus other small fixes

### DIFF
--- a/tlsa
+++ b/tlsa
@@ -32,7 +32,7 @@ import unbound
 import subprocess
 import re
 from M2Crypto import X509, SSL, BIO, m2
-from binascii import a2b_hex, b2a_hex
+from binascii import b2a_hex
 from hashlib import sha256, sha512
 from ipaddress import IPv4Address, IPv6Address
 

--- a/tlsa
+++ b/tlsa
@@ -261,7 +261,7 @@ def getHash(certificate, mtype):
 	"""
 	certificate = certificate.as_der()
 	if mtype == 0:
-		return b2a_hex(certificate)
+		return certificate.hex()
 	elif mtype == 1:
 		return sha256(certificate).hexdigest()
 	elif mtype == 2:

--- a/tlsa
+++ b/tlsa
@@ -116,7 +116,7 @@ def genRecords(hostname, protocol, port, chain, output='rfc', usage=1, selector=
 
 def getA(hostname, secure=True):
 	"""Gets a list of A records for hostname, returns a list of ARecords"""
-	records = ""
+	records = []
 	try:
 		records = getRecords(hostname, rrtype='A', secure=secure)
 	except InsecureLookupException as e:
@@ -129,8 +129,8 @@ def getA(hostname, secure=True):
 	return ret
 
 def getAAAA(hostname, secure=True):
-	"""Gets a list of A records for hostname, returns a list of AAAARecords"""
-	records = ""
+	"""Gets a list of AAAA records for hostname, returns a list of AAAARecords"""
+	records = []
 	try:
 		records = getRecords(hostname, rrtype='AAAA', secure=secure)
 	except InsecureLookupException as e:


### PR DESCRIPTION
before:
```
_443._tcp.pdns-public-ns1.powerdns.com. IN TLSA 3 1 0 b'30820122300d06092a864886f70d01010105000382010f003082010a0282010100cb8d1f75a0dd1a55a0c14bdfd4413be868ba8f8d3d7c58bd308186282f51d54ab42cde18197fe70230a45d7d2c71adbecc2180964a2e79cc624db66fbd755f6c0facb58cf7dcac3cbd29e61802ba7cb73045369236a0d08a24d34304f1abab99ceb0aabdff1dad3469e2c041abbf96c1f38fd7496d253b23509a97ff743c8b2c186b751c2a3b9b0ba82b13ce1b6c6de411dcb4f3a128e552c79be320f8322330a8c582643981d34c62e7a617b3dca2feeefcac03edd3a7943e2816be58cd4724830807a5326a17042b31b1ebe8c9eca4957106a4c0a73942c703515ce0e28bd17237630c11126adb26c5077e365f6043cea5d7bb1e2e9ad5fc3909a848174df50203010001'
```

after:
```
_443._tcp.pdns-public-ns1.powerdns.com. IN TLSA 3 1 0 30820122300d06092a864886f70d01010105000382010f003082010a0282010100cb8d1f75a0dd1a55a0c14bdfd4413be868ba8f8d3d7c58bd308186282f51d54ab42cde18197fe70230a45d7d2c71adbecc2180964a2e79cc624db66fbd755f6c0facb58cf7dcac3cbd29e61802ba7cb73045369236a0d08a24d34304f1abab99ceb0aabdff1dad3469e2c041abbf96c1f38fd7496d253b23509a97ff743c8b2c186b751c2a3b9b0ba82b13ce1b6c6de411dcb4f3a128e552c79be320f8322330a8c582643981d34c62e7a617b3dca2feeefcac03edd3a7943e2816be58cd4724830807a5326a17042b31b1ebe8c9eca4957106a4c0a73942c703515ce0e28bd17237630c11126adb26c5077e365f6043cea5d7bb1e2e9ad5fc3909a848174df50203010001
```
