### PR TITLE
Fix non-deterministic TLSA verify exit status behavior

### DIFF
--- a/tlsa
+++ b/tlsa
@@ -703,9 +703,8 @@ if __name__ == '__main__':
 		records = getTLSA(args.host, args.port, args.protocol, secure)
 		if len(records) == 0:
 			sys.exit(1)
-
+		pre_exit = 0
 		for record in records:
-			pre_exit = 0
 			# First, check if the first three fields have correct values.
 			if args.debug:
 				print('Received the following record for name %s:' % record.name)


### PR DESCRIPTION
Hi,

I believe this pull request fixes a bug that causes the exit status to be determined by the order in which the TLSA records are processed.

```
$ tlsa --verify <domain>
FAIL (Usage 3 [DANE-EE]): Certificate offered by the server does not match the TLSA record ()
SUCCESS (Usage 3 [DANE-EE]): Certificate offered by the server matches the TLSA record ()
$ echo $?
0
```

```
$ tlsa --verify <domain>
SUCCESS (Usage 3 [DANE-EE]): Certificate offered by the server matches the TLSA record ()
FAIL (Usage 3 [DANE-EE]): Certificate offered by the server does not match the TLSA record ()
$ echo $?
2
```