### PR TITLE
Update cauldron and add cert name validation for tlsa issue #42

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
-v3.3 (Jan, 2, 2023)
-- tlsa: Add /usr/share/dns/root.key to cauldron
-- tlsa: Give warning on TLSA create routine for certificate name mismatch to hostname provided
+v3.3 (unreleased)
+- tlsa: Add /usr/share/dns/root.key to cauldron [Vijay Sarvepalli]
+- tlsa: Give warning on TLSA create routine for certificate name mismatch to hostname provided [Vijay Sarvepalli]
 
 v3.2 (May, 4, 2022)
 - openpgpkey: fix fetch option [Dirk Stöcker]

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+v3.3 (Jan, 2, 2023)
+- tlsa: Add /usr/share/dns/root.key to cauldron
+- tlsa: Give warning on TLSA create routine for certificate name mismatch to hostname provided
+
 v3.2 (May, 4, 2022)
 - openpgpkey: fix fetch option [Dirk Stöcker]
 - sshfp: fix UTF-8 encoding issue [Dirk Stöcker]

--- a/tlsa
+++ b/tlsa
@@ -23,7 +23,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-VERSION="3.2"
+VERSION="3.3"
 
 import sys
 import os
@@ -37,7 +37,7 @@ from hashlib import sha256, sha512
 from ipaddress import IPv4Address, IPv6Address
 
 ROOTKEY="none"
-cauldron = ( "/var/lib/unbound/root.anchor", "/var/lib/unbound/root.key", "/etc/unbound/root.key" )
+cauldron = ( "/var/lib/unbound/root.anchor", "/var/lib/unbound/root.key", "/etc/unbound/root.key", "/usr/share/dns/root.key" )
 for root in cauldron:
 	if os.path.isfile(root):
 		ROOTKEY=root
@@ -880,6 +880,8 @@ if __name__ == '__main__':
 					continue
 
 				chain = connection.get_peer_cert_chain()
+				if not verifyCertNameWithHostName(cert=chain[0], hostname=str(args.host), with_msg=args.debug):
+					print('WARNING: Certificate name does not match the hostname')
 				genRecords(args.host, address, args.protocol, args.port, chain, args.output, args.usage, args.selector, args.mtype)
 				# Cleanup the connection and context
 				connection.clear()


### PR DESCRIPTION
Addressing issues raised https://github.com/letoams/hash-slinger/issues/42 

- tlsa: Add /usr/share/dns/root.key to cauldron
- tlsa: Give warning on TLSA create routine for certificate name mismatch to hostname provided
Vijay

