### PR TITLE
fix generic TLSA record generation

### DIFF
--- a/tlsa
+++ b/tlsa
@@ -513,7 +513,7 @@ class TLSARecord:
 	def getRecord(self, generic=False):
 		"""Returns the RR string of this TLSARecord, either in rfc (default) or generic format"""
 		if generic:
-			return '%s IN TYPE52 \# %s %s%s%s%s' % (self.name, (len(self.cert)/2)+3 , self._toHex(self.usage), self._toHex(self.selector), self._toHex(self.mtype), self.cert)
+			return '%s IN TYPE52 \# %s %s%s%s%s' % (self.name, (len(self.cert)//2)+3 , self._toHex(self.usage), self._toHex(self.selector), self._toHex(self.mtype), self.cert)
 		return '%s IN TLSA %s %s %s %s' % (self.name, self.usage, self.selector, self.mtype, self.cert)
 
 	def _toHex(self, val):


### PR DESCRIPTION
It seems like the calculation for the TLSA record never really worked, as we're doing float division here on the `len()` field. In our case, that field returned `35.0` which is not valid in our environment.

Doing an integer division gives the correct result in most cases, I believe.

Credits go to @jcharaoui who found the bug, diagnosed it to that specific line, and proposed a fix (a `int()` cast which I turned into integer division instead).

Closes: #45 